### PR TITLE
Performance optmisation for COPY-STREAM-TO-STREAM

### DIFF
--- a/uiop/stream.lisp
+++ b/uiop/stream.lisp
@@ -351,7 +351,7 @@ Otherwise, using WRITE-SEQUENCE using a buffer of size BUFFER-SIZE."
                  (when eof (return)))
           (loop
             :with buffer-size = (or buffer-size 8192)
-            :for buffer = (make-array (list buffer-size) :element-type (or element-type 'character))
+            :with buffer = (make-array (list buffer-size) :element-type (or element-type 'character))
             :for end = (read-sequence buffer input)
             :until (zerop end)
             :do (write-sequence buffer output :end end)


### PR DESCRIPTION
Previously, the buffer was reallocated for every block copied. This
change ensures that the same buffer is being reused.
