### PR TITLE
Bugfix wasn't working on sbcl-windows <= 1.3.15, message: 'error open…

### DIFF
--- a/uiop/stream.lisp
+++ b/uiop/stream.lisp
@@ -591,10 +591,13 @@ Finally, the file will be deleted, unless the KEEP argument when CALL-FUNCTION'e
       :with prefix-nns = (native-namestring prefix-pn)
       :with results = (progn (ensure-directories-exist prefix-pn)
                              ())
-      :for counter :from (random (expt 36 #-gcl 8 #+gcl 5))
-      :for pathname = (parse-native-namestring
-                       (format nil "~A~36R~@[~A~]~@[.~A~]"
-                               prefix-nns counter suffix (unless (eq type :unspecific) type)))
+      :for pathname = (loop
+			 :for counter :from (random (expt 36 #-gcl 8 #+gcl 5))
+			 :for pathname = (parse-native-namestring
+					 (format nil "~A~36R~@[~A~]~@[.~A~]"
+						 prefix-nns counter suffix (unless (eq type :unspecific) type)))
+			 :while (probe-file* pathname)
+			 :finally (return pathname))
       :for okp = nil :do
         ;; TODO: on Unix, do something about umask
         ;; TODO: on Unix, audit the code so we make sure it uses O_CREAT|O_EXCL


### PR DESCRIPTION
…ing #PC:/Users/LinkFly/AppData/Local/Temp/tmpGHU3ALSV.tmp: File exists';  Reason: bug in sbcl into with-open-file (when it is calling with :if-exists nil,  see: https://bugs.launchpad.net/sbcl/+bug/1674437 ). I have fixed for properly work on old (<= 1.3.15) sbcl versions.