### PR TITLE
Fixed a primary-system-name for systems where source-file is unknown.

### DIFF
--- a/system.lisp
+++ b/system.lisp
@@ -144,9 +144,11 @@ the system-primary-system-name of its system."
       (symbol (primary-system-name (coerce-name system-designator)))
       (component (let* ((system (component-system system-designator))
                         (source-file (physicalize-pathname (system-source-file system))))
-                   (and source-file
-                        (equal (pathname-type source-file) "asd")
-                        (pathname-name source-file))))))
+                   (or
+                    (and source-file
+                         (equal (pathname-type source-file) "asd")
+                         (pathname-name source-file))
+                    (component-name system))))))
 
   (defun primary-system-p (system)
     "Given a system designator SYSTEM, return T if it designates a primary system, or else NIL.


### PR DESCRIPTION
Some systems, like "asdf" and "uiop" don't have a source file:

```lisp
CL-USER> (asdf:system-source-file (asdf:component-system (asdf:find-system "asdf")))
NIL
```

asdf:primary-system-name returns NIL for these systems. This can lead to other errors.
For example, it is impossible to call asdf:system-license for these systems because it
uses primary system to get the slot value:

```lisp
CL-USER> (asdf:system-license (asdf:find-system "asdf"))

NIL is not a valid system name
   [Condition of type ASDF/SESSION:FORMATTED-SYSTEM-DEFINITION-ERROR]

Restarts:
 0: [RETRY] Retry SLY mREPL evaluation request.
 1: [*ABORT] Return to SLY's top level.
 2: [ABORT] abort thread (#<THREAD "sly-channel-1-mrepl-remote-1" RUNNING {100394D853}>)

Backtrace:
 0: (ASDF/SESSION:SYSDEF-ERROR "~@<NIL is not a valid system name~@:>")
 1: (ASDF/SYSTEM::SYSTEM-VIRTUAL-SLOT-VALUE #<ASDF/SYSTEM:SYSTEM "asdf"> ASDF/COMPONENT:LICENCE)
 2: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ASDF/SYSTEM:SYSTEM-LICENSE (ASDF/SYSTEM:FIND-SYSTEM "asdf")) #<NULL-LEXENV>)
 3: (EVAL (ASDF/SYSTEM:SYSTEM-LICENSE (ASDF/SYSTEM:FIND-SYSTEM "asdf")))
```