### PR TITLE
Fixed this bug https://github.com/svetlyak40wt/asdf-just-done-bug/

### DIFF
--- a/plan.lisp
+++ b/plan.lisp
@@ -300,6 +300,9 @@ initialized with SEED."
                       ((and action-status (or (status-keep-p action-status)
                                               (and just-done (status-stamp action-status))))
                        (merge-action-status action-status status))
+		      ((and just-done
+                            (not (status-need-p action-status)))
+                        status)
                       (just-done
                        ;; It's OK to lose some ASDF action stamps during self-upgrade
                        (unless (equal "asdf" (primary-system-name dc))


### PR DESCRIPTION
WARNING: \Computing just-done stamp  for action (ASDF/LISP-ACTION:LOAD-OP foo/foo file-type), but dependency (ASDF/LISP-ACTION:COMPILE-OP foo/foo file-type) wasn't done yet!